### PR TITLE
feature: implement Kafka message producer with room-based topics

### DIFF
--- a/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
@@ -1,5 +1,6 @@
 package ru.vrata.backend.domain.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ru.vrata.backend.domain.model.Message;
 import ru.vrata.backend.domain.repository.ChatRoomRepository;
@@ -7,6 +8,7 @@ import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 import ru.vrata.backend.infrastructure.kafka.producer.KafkaProducer;
 
 @Service
+@Slf4j
 public class MessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final KafkaProducer kafkaProducer;
@@ -20,6 +22,13 @@ public class MessageService {
         var room = chatRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("Room not found"));
         // TODO: check that user is in the room
         Message message = Message.create(room.id(), userId, username, content);
+        log.info(
+                "Creating message: messageId={}, roomId={}, userId={}, username={}",
+                message.id(),
+                message.roomId(),
+                message.userId(),
+                message.username()
+        );
         KafkaMessage kafkaMessage = new KafkaMessage(
                 message.id().toString(),
                 message.roomId(),

--- a/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
@@ -1,8 +1,32 @@
 package ru.vrata.backend.domain.service;
 
 import org.springframework.stereotype.Service;
+import ru.vrata.backend.domain.model.Message;
+import ru.vrata.backend.domain.repository.ChatRoomRepository;
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+import ru.vrata.backend.infrastructure.kafka.producer.KafkaProducer;
 
 @Service
 public class MessageService {
-    // TODO: check user in room + send to kafka
+    private final ChatRoomRepository chatRoomRepository;
+    private final KafkaProducer kafkaProducer;
+
+    public MessageService(ChatRoomRepository chatRoomRepository, KafkaProducer kafkaProducer) {
+        this.chatRoomRepository = chatRoomRepository;
+        this.kafkaProducer = kafkaProducer;
+    }
+
+    public void sendMessage(Long roomId, Long userId, String username, String content) {
+        var room = chatRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("Room not found"));
+        // TODO: check that user is in the room
+        Message message = Message.create(room.id(), userId, username, content);
+        KafkaMessage kafkaMessage = new KafkaMessage(
+                message.id().toString(),
+                message.roomId(),
+                message.userId(),
+                message.username(),
+                message.content()
+        );
+        kafkaProducer.produce(kafkaMessage);
+    }
 }

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/KafkaConfig.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/KafkaConfig.java
@@ -1,0 +1,31 @@
+package ru.vrata.backend.infrastructure.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+    @Bean
+    public ProducerFactory<String, KafkaMessage> producerFactory(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, KafkaMessage> kafkaTemplate(ProducerFactory<String, KafkaMessage> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducer.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducer.java
@@ -1,13 +1,21 @@
 package ru.vrata.backend.infrastructure.kafka.producer;
 
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
 @Component
 public class KafkaProducer {
-    // TODO: send to topic + logs
+
+    private final KafkaTemplate<String, KafkaMessage> kafkaTemplate;
+
+    public KafkaProducer(KafkaTemplate<String, KafkaMessage> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
 
     public void produce(KafkaMessage message) {
-        // TODO: send message
+        String topic = "chat-room-" + message.roomId();
+        kafkaTemplate.send(topic, message.id(), message);
+        System.out.println("Kafka producer sent message to topic=" + topic + " message=" + message);
     }
 }

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducer.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducer.java
@@ -1,10 +1,12 @@
 package ru.vrata.backend.infrastructure.kafka.producer;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
 @Component
+@Slf4j
 public class KafkaProducer {
 
     private final KafkaTemplate<String, KafkaMessage> kafkaTemplate;
@@ -16,6 +18,12 @@ public class KafkaProducer {
     public void produce(KafkaMessage message) {
         String topic = "chat-room-" + message.roomId();
         kafkaTemplate.send(topic, message.id(), message);
-        System.out.println("Kafka producer sent message to topic=" + topic + " message=" + message);
+        log.info(
+                "Kafka message sent: topic={}, messageId={}, roomId={}, userId={}",
+                topic,
+                message.id(),
+                message.roomId(),
+                message.userId()
+        );
     }
 }

--- a/backend/src/test/java/ru/vrata/backend/domain/service/MessageServiceTest.java
+++ b/backend/src/test/java/ru/vrata/backend/domain/service/MessageServiceTest.java
@@ -1,0 +1,43 @@
+package ru.vrata.backend.domain.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import ru.vrata.backend.domain.model.ChatRoom;
+import ru.vrata.backend.domain.repository.ChatRoomRepository;
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+import ru.vrata.backend.infrastructure.kafka.producer.KafkaProducer;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MessageServiceTest {
+    @Test
+    void sendMessageShouldSendMessage() {
+        ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
+        KafkaProducer kafkaProducer = mock(KafkaProducer.class);
+        MessageService service = new MessageService(chatRoomRepository, kafkaProducer);
+        ChatRoom room = ChatRoom.create(1L, "test-room");
+        when(chatRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        service.sendMessage(1L, 10L, "username", "test");
+        ArgumentCaptor<KafkaMessage> captor = ArgumentCaptor.forClass(KafkaMessage.class);
+        verify(kafkaProducer).produce(captor.capture());
+        KafkaMessage sentMessage = captor.getValue();
+        assertEquals(1L, sentMessage.roomId());
+        assertEquals(10L, sentMessage.userId());
+        assertEquals("username", sentMessage.username());
+        assertEquals("test", sentMessage.content());
+        assertNotNull(sentMessage.id());
+    }
+
+    @Test
+    void sendMessageShouldThrowIfRoomNotFound() {
+        ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
+        KafkaProducer kafkaProducer = mock(KafkaProducer.class);
+        MessageService service = new MessageService(chatRoomRepository, kafkaProducer);
+        when(chatRoomRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(IllegalArgumentException.class, () -> service.sendMessage(1L, 10L, "username", "test"));
+        verifyNoInteractions(kafkaProducer);
+    }
+}

--- a/backend/src/test/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducerTest.java
+++ b/backend/src/test/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducerTest.java
@@ -1,0 +1,20 @@
+package ru.vrata.backend.infrastructure.kafka.producer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.KafkaTemplate;
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class KafkaProducerTest {
+    @Test
+    void produceShouldSendMessageToTopic() {
+        KafkaTemplate<String, KafkaMessage> kafkaTemplate = mock(KafkaTemplate.class);
+        KafkaProducer producer = new KafkaProducer(kafkaTemplate);
+        KafkaMessage message = new KafkaMessage("message-1", 1L, 10L, "username", "test");
+        producer.produce(message);
+        verify(kafkaTemplate).send(eq("chat-room-1"), eq("message-1"), eq(message));
+    }
+}


### PR DESCRIPTION
Implemented Kafka message producer with one topic per chat room. Messages are created in MessageService, converted to KafkaMessage, and sent via KafkaProducer using format chat-room-<roomId>. Added basic validation for room existence, unit tests for MessageService and KafkaProducer

Closes #14 