### PR TITLE
feature: validate user membership before sending message

### DIFF
--- a/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
@@ -20,7 +20,9 @@ public class MessageService {
 
     public void sendMessage(Long roomId, Long userId, String username, String content) {
         var room = chatRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("Room not found"));
-        // TODO: check that user is in the room
+        if (!chatRoomRepository.isUserInRoom(roomId, userId)) {
+            throw new IllegalArgumentException("User is not in the room");
+        }
         Message message = Message.create(room.id(), userId, username, content);
         log.info(
                 "Creating message: messageId={}, roomId={}, userId={}, username={}",

--- a/backend/src/test/java/ru/vrata/backend/domain/service/MessageServiceTest.java
+++ b/backend/src/test/java/ru/vrata/backend/domain/service/MessageServiceTest.java
@@ -1,5 +1,6 @@
 package ru.vrata.backend.domain.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import ru.vrata.backend.domain.model.ChatRoom;
@@ -13,13 +14,23 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class MessageServiceTest {
+
+    private ChatRoomRepository chatRoomRepository;
+    private KafkaProducer kafkaProducer;
+    private MessageService service;
+
+    @BeforeEach
+    void setUp() {
+        chatRoomRepository = mock(ChatRoomRepository.class);
+        kafkaProducer = mock(KafkaProducer.class);
+        service = new MessageService(chatRoomRepository, kafkaProducer);
+    }
+
     @Test
     void sendMessageShouldSendMessage() {
-        ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
-        KafkaProducer kafkaProducer = mock(KafkaProducer.class);
-        MessageService service = new MessageService(chatRoomRepository, kafkaProducer);
         ChatRoom room = ChatRoom.create(1L, "test-room");
         when(chatRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(chatRoomRepository.isUserInRoom(1L, 10L)).thenReturn(true);
         service.sendMessage(1L, 10L, "username", "test");
         ArgumentCaptor<KafkaMessage> captor = ArgumentCaptor.forClass(KafkaMessage.class);
         verify(kafkaProducer).produce(captor.capture());
@@ -33,10 +44,16 @@ class MessageServiceTest {
 
     @Test
     void sendMessageShouldThrowIfRoomNotFound() {
-        ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
-        KafkaProducer kafkaProducer = mock(KafkaProducer.class);
-        MessageService service = new MessageService(chatRoomRepository, kafkaProducer);
         when(chatRoomRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(IllegalArgumentException.class, () -> service.sendMessage(1L, 10L, "username", "test"));
+        verifyNoInteractions(kafkaProducer);
+    }
+
+    @Test
+    void sendMessageShouldThrowIfUserNotInRoom() {
+        ChatRoom room = ChatRoom.create(1L, "test-room");
+        when(chatRoomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(chatRoomRepository.isUserInRoom(1L, 10L)).thenReturn(false);
         assertThrows(IllegalArgumentException.class, () -> service.sendMessage(1L, 10L, "username", "test"));
         verifyNoInteractions(kafkaProducer);
     }


### PR DESCRIPTION
Added validation in MessageService to ensure that a user is a member of the chat room before sending a message using Kafka producer. If the user is not in the room, an exception is thrown, added a new test case to cover this scenario. Refactored MessageServiceTest to use `@BeforeEach` for setup.