### PR TITLE
fix: message history

### DIFF
--- a/backend/api.yaml
+++ b/backend/api.yaml
@@ -176,18 +176,11 @@ paths:
   /api/v1/rooms/{roomId}/messages:
     get:
       tags: [Messages]
-      summary: Get delivered messages for user in room
+      summary: Get room messages
       operationId: getRoomMessages
       parameters:
         - name: roomId
           in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-            minimum: 1
-        - name: userId
-          in: query
           required: true
           schema:
             type: integer
@@ -379,7 +372,7 @@ components:
 
     MessageResponse:
       type: object
-      required: [id, roomId, userId, username, content]
+      required: [id, roomId, userId, username, content, timestamp]
       properties:
         id:
           type: string
@@ -398,6 +391,10 @@ components:
         content:
           type: string
           example: Hello team
+        timestamp:
+          type: string
+          format: date-time
+          example: 2026-04-25T08:00:00Z
 
     AuthEvent:
       type: object
@@ -456,8 +453,9 @@ x-websocket-integration:
           userId: 42
           username: rolan
           content: Hello team
+          timestamp: 2026-04-25T08:00:00Z
     flow:
-      history: Load existing room messages with GET /api/v1/rooms/{roomId}/messages?userId={userId}.
+      history: Load existing room messages with GET /api/v1/rooms/{roomId}/messages.
       send: Send messages with POST /api/v1/messages.
       live: Subscribe to the room topic to receive new messages after Kafka delivery.
     notes:

--- a/backend/src/main/java/ru/vrata/backend/api/message/MessageController.java
+++ b/backend/src/main/java/ru/vrata/backend/api/message/MessageController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import ru.vrata.backend.api.message.dto.MessageResponse;
@@ -38,10 +37,9 @@ public class MessageController {
     }
 
     @GetMapping("/rooms/{roomId}/messages")
-    public List<MessageResponse> getRoomMessages(@PathVariable Long roomId,
-                                                 @RequestParam Long userId)
+    public List<MessageResponse> getRoomMessages(@PathVariable Long roomId)
     {
-        return messageService.getMessagesForRoom(roomId, userId).stream()
+        return messageService.getMessagesForRoom(roomId).stream()
                 .map(MessageResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/ru/vrata/backend/api/message/dto/MessageResponse.java
+++ b/backend/src/main/java/ru/vrata/backend/api/message/dto/MessageResponse.java
@@ -1,8 +1,8 @@
 package ru.vrata.backend.api.message.dto;
 
 import ru.vrata.backend.domain.model.Message;
-import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public record MessageResponse(
@@ -10,7 +10,8 @@ public record MessageResponse(
         Long roomId,
         Long userId,
         String username,
-        String content
+        String content,
+        Instant timestamp
 ) {
     public static MessageResponse from(Message message) {
         return new MessageResponse(
@@ -18,7 +19,8 @@ public record MessageResponse(
                 message.roomId(),
                 message.userId(),
                 message.username(),
-                message.content()
+                message.content(),
+                message.timestamp()
         );
     }
 }

--- a/backend/src/main/java/ru/vrata/backend/domain/model/Message.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/model/Message.java
@@ -2,9 +2,11 @@ package ru.vrata.backend.domain.model;
 
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.UUID;
 
-public record Message(UUID id, Long roomId, Long userId, String username, String content) {
+public record Message(UUID id, Long roomId, Long userId, String username, String content, Instant timestamp) {
     public Message {
         if (id == null) {
             throw new IllegalArgumentException("message id must not be null");
@@ -15,16 +17,37 @@ public record Message(UUID id, Long roomId, Long userId, String username, String
         if (userId == null || userId <= 0) {
             throw new IllegalArgumentException("user id must be positive");
         }
+        if (timestamp == null) {
+            throw new IllegalArgumentException("timestamp must not be null");
+        }
         username = User.normalizeUsername(username);
         content = normalizeContent(content);
     }
 
     public static Message create(Long roomId, Long userId, String username, String content) {
-        return new Message(UUID.randomUUID(), roomId, userId, username, content);
+        return new Message(UUID.randomUUID(), roomId, userId, username, content, Instant.now());
     }
 
     public static Message from(KafkaMessage kafkaMessage) {
-        return new Message(UUID.randomUUID(), kafkaMessage.roomId(), kafkaMessage.userId(), kafkaMessage.username(), kafkaMessage.content());
+        return new Message(
+                toStableUuid(kafkaMessage.id()),
+                kafkaMessage.roomId(),
+                kafkaMessage.userId(),
+                kafkaMessage.username(),
+                kafkaMessage.content(),
+                kafkaMessage.timestamp()
+        );
+    }
+
+    private static UUID toStableUuid(String rawId) {
+        if (rawId == null) {
+            throw new IllegalArgumentException("message id must not be null");
+        }
+        try {
+            return UUID.fromString(rawId);
+        } catch (RuntimeException ignored) {
+            return UUID.nameUUIDFromBytes(rawId.getBytes(StandardCharsets.UTF_8));
+        }
     }
 
     public static String normalizeContent(String raw) {

--- a/backend/src/main/java/ru/vrata/backend/domain/repository/RoomMessageRepository.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/repository/RoomMessageRepository.java
@@ -1,0 +1,11 @@
+package ru.vrata.backend.domain.repository;
+
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+
+import java.util.List;
+
+public interface RoomMessageRepository {
+    void saveForRoom(Long roomId, KafkaMessage message);
+
+    List<KafkaMessage> findByRoomId(Long roomId);
+}

--- a/backend/src/main/java/ru/vrata/backend/domain/repository/inmemory/InMemoryDeliveredMessageRepository.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/repository/inmemory/InMemoryDeliveredMessageRepository.java
@@ -5,6 +5,7 @@ import ru.vrata.backend.domain.repository.DeliveredMessageRepository;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +29,18 @@ public class InMemoryDeliveredMessageRepository implements DeliveredMessageRepos
 
     @Override
     public List<KafkaMessage> findByRoomId(Long roomId) {
-        return List.copyOf(inboxByUserId.getOrDefault(roomId, List.of()));
+        if (roomId == null) {
+            return List.of();
+        }
+
+        Map<String, KafkaMessage> byMessageId = new LinkedHashMap<>();
+        for (List<KafkaMessage> userInbox : inboxByUserId.values()) {
+            for (KafkaMessage message : userInbox) {
+                if (roomId.equals(message.roomId())) {
+                    byMessageId.putIfAbsent(message.id(), message);
+                }
+            }
+        }
+        return List.copyOf(byMessageId.values());
     }
 }

--- a/backend/src/main/java/ru/vrata/backend/domain/repository/inmemory/InMemoryRoomMessageRepository.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/repository/inmemory/InMemoryRoomMessageRepository.java
@@ -1,0 +1,28 @@
+package ru.vrata.backend.domain.repository.inmemory;
+
+import org.springframework.stereotype.Repository;
+import ru.vrata.backend.domain.repository.RoomMessageRepository;
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryRoomMessageRepository implements RoomMessageRepository {
+
+    private final Map<Long, List<KafkaMessage>> messagesByRoomId = new ConcurrentHashMap<>();
+
+    @Override
+    public synchronized void saveForRoom(Long roomId, KafkaMessage message) {
+        messagesByRoomId
+                .computeIfAbsent(roomId, id -> new ArrayList<>())
+                .add(message);
+    }
+
+    @Override
+    public List<KafkaMessage> findByRoomId(Long roomId) {
+        return List.copyOf(messagesByRoomId.getOrDefault(roomId, List.of()));
+    }
+}

--- a/backend/src/main/java/ru/vrata/backend/domain/service/KafkaMessageDeliveryService.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/service/KafkaMessageDeliveryService.java
@@ -3,7 +3,7 @@ package ru.vrata.backend.domain.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ru.vrata.backend.domain.repository.ChatRoomRepository;
-import ru.vrata.backend.domain.repository.DeliveredMessageRepository;
+import ru.vrata.backend.domain.repository.RoomMessageRepository;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
 import java.util.Set;
@@ -17,15 +17,15 @@ import java.util.Set;
 public class KafkaMessageDeliveryService {
 
     private final ChatRoomRepository chatRoomRepository;
-    private final DeliveredMessageRepository deliveredMessageRepository;
+    private final RoomMessageRepository roomMessageRepository;
     private final MessageRealtimePublisher messageRealtimePublisher;
 
     public KafkaMessageDeliveryService(ChatRoomRepository chatRoomRepository,
-                                       DeliveredMessageRepository deliveredMessageRepository,
+                                       RoomMessageRepository roomMessageRepository,
                                        MessageRealtimePublisher messageRealtimePublisher)
     {
         this.chatRoomRepository = chatRoomRepository;
-        this.deliveredMessageRepository = deliveredMessageRepository;
+        this.roomMessageRepository = roomMessageRepository;
         this.messageRealtimePublisher = messageRealtimePublisher;
     }
 
@@ -64,17 +64,7 @@ public class KafkaMessageDeliveryService {
             return;
         }
 
-        for (Long memberId : memberIds) {
-            deliveredMessageRepository.saveForUser(memberId, message);
-            log.info(
-                    "Delivery: messageId={} delivered to userId={} in roomId={}",
-                    message.id(),
-                    memberId,
-                    message.roomId()
-            );
-
-
-        }
+        roomMessageRepository.saveForRoom(message.roomId(), message);
 
         messageRealtimePublisher.publish(message);
 

--- a/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/service/MessageService.java
@@ -2,10 +2,9 @@ package ru.vrata.backend.domain.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import ru.vrata.backend.api.message.dto.MessageResponse;
 import ru.vrata.backend.domain.model.Message;
 import ru.vrata.backend.domain.repository.ChatRoomRepository;
-import ru.vrata.backend.domain.repository.DeliveredMessageRepository;
+import ru.vrata.backend.domain.repository.RoomMessageRepository;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 import ru.vrata.backend.infrastructure.kafka.producer.KafkaProducer;
 
@@ -15,15 +14,15 @@ import java.util.List;
 @Slf4j
 public class MessageService {
     private final ChatRoomRepository chatRoomRepository;
-    private final DeliveredMessageRepository deliveredMessageRepository;
+    private final RoomMessageRepository roomMessageRepository;
     private final KafkaProducer kafkaProducer;
 
     public MessageService(ChatRoomRepository chatRoomRepository,
-                          DeliveredMessageRepository deliveredMessageRepository,
+                          RoomMessageRepository roomMessageRepository,
                           KafkaProducer kafkaProducer)
     {
         this.chatRoomRepository = chatRoomRepository;
-        this.deliveredMessageRepository = deliveredMessageRepository;
+        this.roomMessageRepository = roomMessageRepository;
         this.kafkaProducer = kafkaProducer;
     }
 
@@ -45,32 +44,22 @@ public class MessageService {
                 message.roomId(),
                 message.userId(),
                 message.username(),
-                message.content()
+                message.content(),
+                message.timestamp()
         );
         kafkaProducer.produce(kafkaMessage);
     }
 
-    public List<Message> getMessagesForRoom(Long roomId,  Long userId) {
+    public List<Message> getMessagesForRoom(Long roomId) {
         validateRoomId(roomId);
-        validateUserId(userId);
 
         chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("Room not found"));
 
-        if (!chatRoomRepository.isUserInRoom(roomId, userId)) {
-            throw new IllegalArgumentException("User is not in the room");
-        }
-
-        return deliveredMessageRepository.findByUserId(userId).stream()
-                .filter(message -> roomId.equals(message.roomId()))
+        return roomMessageRepository.findByRoomId(roomId).stream()
                 .map(Message::from)
+                .sorted((left, right) -> left.timestamp().compareTo(right.timestamp()))
                 .toList();
-    }
-
-    private void validateUserId(Long userId) {
-        if (userId == null || userId <= 0) {
-            throw new IllegalArgumentException("user id must be positive");
-        }
     }
 
     private void validateRoomId(Long roomId) {

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/KafkaConfig.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/KafkaConfig.java
@@ -1,5 +1,11 @@
 package ru.vrata.backend.infrastructure.kafka;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -16,18 +22,27 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
+import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
 public class KafkaConfig {
     @Bean
-    public ProducerFactory<String, KafkaMessage> producerFactory(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+    public ProducerFactory<String, KafkaMessage> producerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers
+    ) {
+        ObjectMapper objectMapper = kafkaObjectMapper();
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        return new DefaultKafkaProducerFactory<>(config);
+        return new DefaultKafkaProducerFactory<>(
+                config,
+                new StringSerializer(),
+                new JsonSerializer<>(objectMapper.copy())
+        );
     }
 
     @Bean
@@ -41,6 +56,7 @@ public class KafkaConfig {
             @Value("${spring.kafka.consumer.auto-offset-reset:earliest}") String autoOffsetReset,
             @Value("${spring.kafka.consumer.properties.metadata.max.age.ms:5000}") Integer metadataMaxAgeMs
     ) {
+        ObjectMapper objectMapper = kafkaObjectMapper();
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -49,7 +65,32 @@ public class KafkaConfig {
         config.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, metadataMaxAgeMs);
         config.put(JsonDeserializer.TRUSTED_PACKAGES, "ru.vrata.backend.infrastructure.kafka");
         config.put(JsonDeserializer.VALUE_DEFAULT_TYPE, KafkaMessage.class);
-        return new DefaultKafkaConsumerFactory<>(config);
+        return new DefaultKafkaConsumerFactory<>(
+                config,
+                new StringDeserializer(),
+                new JsonDeserializer<>(KafkaMessage.class, objectMapper.copy(), false)
+        );
+    }
+
+    private ObjectMapper kafkaObjectMapper() {
+        SimpleModule instantModule = new SimpleModule();
+        instantModule.addSerializer(Instant.class, new com.fasterxml.jackson.databind.JsonSerializer<>() {
+            @Override
+            public void serialize(Instant value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+                gen.writeString(value.toString());
+            }
+        });
+        instantModule.addDeserializer(Instant.class, new com.fasterxml.jackson.databind.JsonDeserializer<>() {
+            @Override
+            public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                String raw = p.getValueAsString();
+                if (raw == null || raw.isBlank()) {
+                    return null;
+                }
+                return Instant.parse(raw);
+            }
+        });
+        return new ObjectMapper().registerModule(instantModule);
     }
 
     @Bean

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/KafkaMessage.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/KafkaMessage.java
@@ -1,7 +1,16 @@
 package ru.vrata.backend.infrastructure.kafka;
 
+import java.time.Instant;
+
 /**
  * General model for both consumer and producer
  */
-public record KafkaMessage(String id, Long roomId, Long userId, String username, String content) {
+public record KafkaMessage(
+        String id,
+        Long roomId,
+        Long userId,
+        String username,
+        String content,
+        Instant timestamp
+) {
 }

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/consumer/KafkaMessageConsumer.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/kafka/consumer/KafkaMessageConsumer.java
@@ -68,6 +68,7 @@ public class KafkaMessageConsumer {
                 && message.username() != null
                 && !message.username().isBlank()
                 && message.content() != null
-                && !message.content().isBlank();
+                && !message.content().isBlank()
+                && message.timestamp() != null;
     }
 }

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/migration/V003AddMessageTimestampMigration.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/migration/V003AddMessageTimestampMigration.java
@@ -1,0 +1,41 @@
+package ru.vrata.backend.infrastructure.mongo.migration;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V003AddMessageTimestampMigration implements MongoMigration {
+
+    @Override
+    public String id() {
+        return "V003_ADD_MESSAGE_TIMESTAMP";
+    }
+
+    @Override
+    public void execute(MongoTemplate mongoTemplate) {
+        Query missingTimestampQuery = Query.query(
+                new Criteria().orOperator(
+                        Criteria.where("timestamp").exists(false),
+                        Criteria.where("timestamp").is(null)
+                )
+        );
+
+        mongoTemplate.updateMulti(
+                missingTimestampQuery,
+                new Update().currentDate("timestamp"),
+                "messages"
+        );
+
+        mongoTemplate.indexOps("messages")
+                .ensureIndex(
+                        new Index()
+                                .on("roomId", Sort.Direction.ASC)
+                                .on("timestamp", Sort.Direction.ASC)
+                );
+    }
+}

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/websocket/LiveMessagePayload.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/websocket/LiveMessagePayload.java
@@ -2,12 +2,15 @@ package ru.vrata.backend.infrastructure.websocket;
 
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
+import java.time.Instant;
+
 public record LiveMessagePayload(
         String id,
         Long roomId,
         Long userId,
         String username,
-        String content
+        String content,
+        Instant timestamp
 ) {
     public static LiveMessagePayload from(KafkaMessage message) {
         return new LiveMessagePayload(
@@ -15,7 +18,8 @@ public record LiveMessagePayload(
                 message.roomId(),
                 message.userId(),
                 message.username(),
-                message.content()
+                message.content(),
+                message.timestamp()
         );
     }
 }

--- a/backend/src/test/java/ru/vrata/backend/api/message/MessageControllerTest.java
+++ b/backend/src/test/java/ru/vrata/backend/api/message/MessageControllerTest.java
@@ -10,6 +10,7 @@ import ru.vrata.backend.api.common.GlobalExceptionHandler;
 import ru.vrata.backend.domain.model.Message;
 import ru.vrata.backend.domain.service.MessageService;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -76,31 +77,33 @@ class MessageControllerTest {
     void getRoomMessagesShouldReturnMessages() throws Exception {
         UUID firstId = UUID.randomUUID();
         UUID secondId = UUID.randomUUID();
-        when(messageService.getMessagesForRoom(7L, 42L)).thenReturn(List.of(
-                new Message(firstId, 7L, 42L, "rolan", "hello"),
-                new Message(secondId, 7L, 99L, "teammate", "hi")
+        Instant firstTimestamp = Instant.parse("2026-04-25T08:00:00Z");
+        Instant secondTimestamp = Instant.parse("2026-04-25T08:01:00Z");
+        when(messageService.getMessagesForRoom(7L)).thenReturn(List.of(
+                new Message(firstId, 7L, 42L, "rolan", "hello", firstTimestamp),
+                new Message(secondId, 7L, 99L, "teammate", "hi", secondTimestamp)
         ));
 
-        mockMvc.perform(get("/api/v1/rooms/7/messages")
-                        .queryParam("userId", "42"))
+        mockMvc.perform(get("/api/v1/rooms/7/messages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
                 .andExpect(jsonPath("$[0].id").value(firstId.toString()))
                 .andExpect(jsonPath("$[0].roomId").value(7))
                 .andExpect(jsonPath("$[0].username").value("rolan"))
+                .andExpect(jsonPath("$[0].timestamp").value(firstTimestamp.toString()))
                 .andExpect(jsonPath("$[1].id").value(secondId.toString()))
-                .andExpect(jsonPath("$[1].username").value("teammate"));
+                .andExpect(jsonPath("$[1].username").value("teammate"))
+                .andExpect(jsonPath("$[1].timestamp").value(secondTimestamp.toString()));
     }
 
     @Test
-    void getRoomMessagesShouldPassRoomAndUserToService() throws Exception {
-        when(messageService.getMessagesForRoom(7L, 42L)).thenReturn(List.of());
+    void getRoomMessagesShouldPassRoomToService() throws Exception {
+        when(messageService.getMessagesForRoom(7L)).thenReturn(List.of());
 
-        mockMvc.perform(get("/api/v1/rooms/7/messages")
-                        .queryParam("userId", "42"))
+        mockMvc.perform(get("/api/v1/rooms/7/messages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(0));
 
-        verify(messageService).getMessagesForRoom(7L, 42L);
+        verify(messageService).getMessagesForRoom(7L);
     }
 }

--- a/backend/src/test/java/ru/vrata/backend/domain/model/DomainModelTest.java
+++ b/backend/src/test/java/ru/vrata/backend/domain/model/DomainModelTest.java
@@ -1,11 +1,14 @@
 package ru.vrata.backend.domain.model;
 
 import org.junit.jupiter.api.Test;
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
 import java.time.Instant;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,6 +48,25 @@ class DomainModelTest {
 
         assertTrue(message.belongsToRoom(1L));
         assertTrue(message.writtenBy(1L));
+    }
+
+    @Test
+    void messageFromKafkaShouldKeepStableId() {
+        String rawId = UUID.randomUUID().toString();
+        KafkaMessage kafkaMessage = new KafkaMessage(
+                rawId,
+                1L,
+                1L,
+                "rolan",
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
+        );
+
+        Message first = Message.from(kafkaMessage);
+        Message second = Message.from(kafkaMessage);
+
+        assertEquals(UUID.fromString(rawId), first.id());
+        assertEquals(first.id(), second.id());
     }
 
     @Test

--- a/backend/src/test/java/ru/vrata/backend/domain/repository/inmemory/InMemoryDeliveredMessageRepositoryTest.java
+++ b/backend/src/test/java/ru/vrata/backend/domain/repository/inmemory/InMemoryDeliveredMessageRepositoryTest.java
@@ -1,0 +1,43 @@
+package ru.vrata.backend.domain.repository.inmemory;
+
+import org.junit.jupiter.api.Test;
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InMemoryDeliveredMessageRepositoryTest {
+
+    @Test
+    void findByRoomIdShouldReturnRoomMessagesWithoutDuplicates() {
+        InMemoryDeliveredMessageRepository repository = new InMemoryDeliveredMessageRepository();
+        KafkaMessage roomOne = new KafkaMessage(
+                "msg-1",
+                1L,
+                10L,
+                "alice",
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
+        );
+        KafkaMessage roomTwo = new KafkaMessage(
+                "msg-2",
+                2L,
+                10L,
+                "alice",
+                "other room",
+                Instant.parse("2026-04-25T08:01:00Z")
+        );
+
+        repository.saveForUser(10L, roomOne);
+        repository.saveForUser(10L, roomTwo);
+        repository.saveForUser(20L, roomOne);
+
+        List<KafkaMessage> found = repository.findByRoomId(1L);
+
+        assertEquals(1, found.size());
+        assertEquals("msg-1", found.get(0).id());
+        assertEquals(1L, found.get(0).roomId());
+    }
+}

--- a/backend/src/test/java/ru/vrata/backend/domain/service/KafkaMessageDeliveryServiceTest.java
+++ b/backend/src/test/java/ru/vrata/backend/domain/service/KafkaMessageDeliveryServiceTest.java
@@ -5,9 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import ru.vrata.backend.domain.model.ChatRoom;
 import ru.vrata.backend.domain.repository.ChatRoomRepository;
-import ru.vrata.backend.domain.repository.inmemory.InMemoryDeliveredMessageRepository;
+import ru.vrata.backend.domain.repository.inmemory.InMemoryRoomMessageRepository;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,18 +22,18 @@ import static org.mockito.Mockito.when;
 class KafkaMessageDeliveryServiceTest {
 
     private ChatRoomRepository chatRoomRepository;
-    private InMemoryDeliveredMessageRepository deliveredMessageRepository;
+    private InMemoryRoomMessageRepository roomMessageRepository;
     private MessageRealtimePublisher messageRealtimePublisher;
     private KafkaMessageDeliveryService deliveryService;
 
     @BeforeEach
     void setUp() {
         chatRoomRepository = Mockito.mock(ChatRoomRepository.class);
-        deliveredMessageRepository = new InMemoryDeliveredMessageRepository();
+        roomMessageRepository = new InMemoryRoomMessageRepository();
         messageRealtimePublisher = Mockito.mock(MessageRealtimePublisher.class);
         deliveryService = new KafkaMessageDeliveryService(
                 chatRoomRepository,
-                deliveredMessageRepository,
+                roomMessageRepository,
                 messageRealtimePublisher
         );
     }
@@ -44,7 +45,8 @@ class KafkaMessageDeliveryServiceTest {
                 1L,
                 10L,
                 "riia",
-                "hello"
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
         );
 
         when(chatRoomRepository.findById(1L)).thenReturn(Optional.empty());
@@ -55,8 +57,7 @@ class KafkaMessageDeliveryServiceTest {
         verify(chatRoomRepository, never()).findMemberIdsByRoomId(Mockito.anyLong());
         verify(messageRealtimePublisher, never()).publish(Mockito.any());
 
-        assertTrue(deliveredMessageRepository.findByUserId(10L).isEmpty());
-        assertTrue(deliveredMessageRepository.findByUserId(20L).isEmpty());
+        assertTrue(roomMessageRepository.findByRoomId(1L).isEmpty());
     }
 
     @Test
@@ -66,7 +67,8 @@ class KafkaMessageDeliveryServiceTest {
                 1L,
                 10L,
                 "riia",
-                "hello"
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
         );
 
         ChatRoom room = new ChatRoom(1L, "test-room", "abcdef");
@@ -79,11 +81,8 @@ class KafkaMessageDeliveryServiceTest {
         verify(chatRoomRepository, times(1)).findById(1L);
         verify(chatRoomRepository, times(1)).findMemberIdsByRoomId(1L);
 
-        assertEquals(1, deliveredMessageRepository.findByUserId(10L).size());
-        assertEquals(1, deliveredMessageRepository.findByUserId(20L).size());
-        assertEquals(message, deliveredMessageRepository.findByUserId(10L).get(0));
-        assertEquals(message, deliveredMessageRepository.findByUserId(20L).get(0));
-        assertTrue(deliveredMessageRepository.findByUserId(30L).isEmpty());
+        assertEquals(1, roomMessageRepository.findByRoomId(1L).size());
+        assertEquals(message, roomMessageRepository.findByRoomId(1L).get(0));
         verify(messageRealtimePublisher, times(1)).publish(message);
     }
 
@@ -94,7 +93,8 @@ class KafkaMessageDeliveryServiceTest {
                 1L,
                 10L,
                 "riia",
-                "hello"
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
         );
 
         ChatRoom room = new ChatRoom(1L, "test-room", "abcdef");
@@ -107,8 +107,7 @@ class KafkaMessageDeliveryServiceTest {
         verify(chatRoomRepository, times(1)).findById(1L);
         verify(chatRoomRepository, times(1)).findMemberIdsByRoomId(1L);
 
-        assertTrue(deliveredMessageRepository.findByUserId(10L).isEmpty());
-        assertTrue(deliveredMessageRepository.findByUserId(20L).isEmpty());
+        assertTrue(roomMessageRepository.findByRoomId(1L).isEmpty());
         verify(messageRealtimePublisher, never()).publish(Mockito.any());
     }
 }

--- a/backend/src/test/java/ru/vrata/backend/domain/service/MessageServiceTest.java
+++ b/backend/src/test/java/ru/vrata/backend/domain/service/MessageServiceTest.java
@@ -6,10 +6,11 @@ import org.mockito.ArgumentCaptor;
 import ru.vrata.backend.domain.model.ChatRoom;
 import ru.vrata.backend.domain.model.Message;
 import ru.vrata.backend.domain.repository.ChatRoomRepository;
-import ru.vrata.backend.domain.repository.DeliveredMessageRepository;
+import ru.vrata.backend.domain.repository.RoomMessageRepository;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 import ru.vrata.backend.infrastructure.kafka.producer.KafkaProducer;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,16 +20,16 @@ import static org.mockito.Mockito.*;
 class MessageServiceTest {
 
     private ChatRoomRepository chatRoomRepository;
-    private DeliveredMessageRepository deliveredMessageRepository;
+    private RoomMessageRepository roomMessageRepository;
     private KafkaProducer kafkaProducer;
     private MessageService service;
 
     @BeforeEach
     void setUp() {
         chatRoomRepository = mock(ChatRoomRepository.class);
-        deliveredMessageRepository = mock(DeliveredMessageRepository.class);
+        roomMessageRepository = mock(RoomMessageRepository.class);
         kafkaProducer = mock(KafkaProducer.class);
-        service = new MessageService(chatRoomRepository, deliveredMessageRepository, kafkaProducer);
+        service = new MessageService(chatRoomRepository, roomMessageRepository, kafkaProducer);
     }
 
     @Test
@@ -44,6 +45,7 @@ class MessageServiceTest {
         assertEquals(10L, sentMessage.userId());
         assertEquals("username", sentMessage.username());
         assertEquals("test", sentMessage.content());
+        assertNotNull(sentMessage.timestamp());
         assertNotNull(sentMessage.id());
     }
 
@@ -64,23 +66,24 @@ class MessageServiceTest {
     }
 
     @Test
-    void getMessagesForRoomShouldReturnMessagesForRoomWhenUserInRoom() {
+    void getMessagesForRoomShouldReturnMessagesForRoom() {
         ChatRoom room = ChatRoom.create(1L, "test-room");
         when(chatRoomRepository.findById(1L)).thenReturn(Optional.of(room));
-        when(chatRoomRepository.isUserInRoom(1L, 10L)).thenReturn(true);
+        Instant firstTimestamp = Instant.parse("2026-04-25T08:00:00Z");
+        Instant secondTimestamp = Instant.parse("2026-04-25T08:01:00Z");
+        KafkaMessage first = new KafkaMessage("id-1", 1L, 10L, "user", "hello", firstTimestamp);
+        KafkaMessage second = new KafkaMessage("id-2", 2L, 10L, "user", "world", secondTimestamp);
+        when(roomMessageRepository.findByRoomId(1L)).thenReturn(List.of(first, second));
 
-        KafkaMessage first = new KafkaMessage("id-1", 1L, 10L, "user", "hello");
-        KafkaMessage second = new KafkaMessage("id-2", 2L, 10L, "user", "world");
-        when(deliveredMessageRepository.findByUserId(10L)).thenReturn(List.of(first, second));
+        List<Message> result = service.getMessagesForRoom(1L);
 
-        List<Message> result = service.getMessagesForRoom(1L, 10L);
-
-        assertEquals(1, result.size());
+        assertEquals(2, result.size());
         Message firstResult = result.get(0);
         assertEquals(1L, firstResult.roomId());
         assertEquals(10L, firstResult.userId());
         assertEquals("user", firstResult.username());
         assertEquals("hello", firstResult.content());
+        assertEquals(firstTimestamp, firstResult.timestamp());
         assertNotNull(firstResult.id());
     }
 
@@ -88,44 +91,23 @@ class MessageServiceTest {
     void getMessagesForRoomShouldThrowIfRoomNotFound() {
         when(chatRoomRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThrows(IllegalArgumentException.class, () -> service.getMessagesForRoom(1L, 10L));
-        verify(chatRoomRepository, never()).isUserInRoom(anyLong(), anyLong());
-        verifyNoInteractions(deliveredMessageRepository);
-    }
-
-    @Test
-    void getMessagesForRoomShouldThrowIfUserNotInRoom() {
-        ChatRoom room = ChatRoom.create(1L, "test-room");
-        when(chatRoomRepository.findById(1L)).thenReturn(Optional.of(room));
-        when(chatRoomRepository.isUserInRoom(1L, 10L)).thenReturn(false);
-
-        assertThrows(IllegalArgumentException.class, () -> service.getMessagesForRoom(1L, 10L));
-        verifyNoInteractions(deliveredMessageRepository);
-    }
-
-    @Test
-    void getMessagesForRoomShouldThrowIfUserIdInvalid() {
-        assertThrows(IllegalArgumentException.class, () -> service.getMessagesForRoom(1L, 0L));
-        verifyNoInteractions(deliveredMessageRepository);
+        assertThrows(IllegalArgumentException.class, () -> service.getMessagesForRoom(1L));
+        verifyNoInteractions(roomMessageRepository);
     }
 
     @Test
     void getMessagesForRoomShouldThrowIfRoomIdInvalid() {
-        assertThrows(IllegalArgumentException.class, () -> service.getMessagesForRoom(0L, 10L));
-        verifyNoInteractions(deliveredMessageRepository);
+        assertThrows(IllegalArgumentException.class, () -> service.getMessagesForRoom(0L));
+        verifyNoInteractions(roomMessageRepository);
     }
 
     @Test
     void getMessagesForRoomShouldReturnEmptyWhenNoMessagesInRoom() {
         ChatRoom room = ChatRoom.create(1L, "test-room");
         when(chatRoomRepository.findById(1L)).thenReturn(Optional.of(room));
-        when(chatRoomRepository.isUserInRoom(1L, 10L)).thenReturn(true);
+        when(roomMessageRepository.findByRoomId(1L)).thenReturn(List.of());
 
-        KafkaMessage first = new KafkaMessage("id-1", 2L, 10L, "user", "hello");
-        KafkaMessage second = new KafkaMessage("id-2", 3L, 10L, "user", "world");
-        when(deliveredMessageRepository.findByUserId(10L)).thenReturn(List.of(first, second));
-
-        List<Message> result = service.getMessagesForRoom(1L, 10L);
+        List<Message> result = service.getMessagesForRoom(1L);
 
         assertTrue(result.isEmpty());
     }

--- a/backend/src/test/java/ru/vrata/backend/flow/ChatMessagingFlowTest.java
+++ b/backend/src/test/java/ru/vrata/backend/flow/ChatMessagingFlowTest.java
@@ -66,8 +66,7 @@ class ChatMessagingFlowTest {
 
         deliverProducedMessages();
 
-        assertUserRoomMessages(firstUserId, room.id());
-        assertUserRoomMessages(secondUserId, room.id());
+        assertRoomMessages(room.id());
     }
 
     private long register(String username, String password) throws Exception {
@@ -149,15 +148,16 @@ class ChatMessagingFlowTest {
         }
     }
 
-    private void assertUserRoomMessages(long userId, long roomId) throws Exception {
-        mockMvc.perform(get("/api/v1/rooms/{roomId}/messages", roomId)
-                        .queryParam("userId", String.valueOf(userId)))
+    private void assertRoomMessages(long roomId) throws Exception {
+        mockMvc.perform(get("/api/v1/rooms/{roomId}/messages", roomId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
                 .andExpect(jsonPath("$[0].roomId").value(roomId))
                 .andExpect(jsonPath("$[1].roomId").value(roomId))
                 .andExpect(jsonPath("$[0].content").value("Hello from Alice"))
-                .andExpect(jsonPath("$[1].content").value("Hello from Bob"));
+                .andExpect(jsonPath("$[1].content").value("Hello from Bob"))
+                .andExpect(jsonPath("$[0].timestamp").isNotEmpty())
+                .andExpect(jsonPath("$[1].timestamp").isNotEmpty());
     }
 
     private long extractLongField(String json, String fieldName) {

--- a/backend/src/test/java/ru/vrata/backend/infrastructure/kafka/consumer/KafkaMessageConsumerTest.java
+++ b/backend/src/test/java/ru/vrata/backend/infrastructure/kafka/consumer/KafkaMessageConsumerTest.java
@@ -6,6 +6,8 @@ import org.mockito.Mockito;
 import ru.vrata.backend.domain.service.KafkaMessageDeliveryService;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
+import java.time.Instant;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,7 +31,8 @@ class KafkaMessageConsumerTest {
                 1L,
                 10L,
                 "riia",
-                "hello"
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
         );
 
         assertDoesNotThrow(() -> consumer.consume(message));
@@ -51,7 +54,8 @@ class KafkaMessageConsumerTest {
                 1L,
                 10L,
                 "riia",
-                "hello"
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
         );
 
         assertDoesNotThrow(() -> consumer.consume(message));
@@ -66,7 +70,8 @@ class KafkaMessageConsumerTest {
                 1L,
                 10L,
                 "   ",
-                "hello"
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
         );
 
         assertDoesNotThrow(() -> consumer.consume(message));
@@ -81,7 +86,24 @@ class KafkaMessageConsumerTest {
                 1L,
                 10L,
                 "riia",
-                "   "
+                "   ",
+                Instant.parse("2026-04-25T08:00:00Z")
+        );
+
+        assertDoesNotThrow(() -> consumer.consume(message));
+
+        verify(deliveryService, never()).deliver(Mockito.any());
+    }
+
+    @Test
+    void consumeShouldIgnoreMessageWithNullTimestampWithoutException() {
+        KafkaMessage message = new KafkaMessage(
+                "msg-4",
+                1L,
+                10L,
+                "riia",
+                "hello",
+                null
         );
 
         assertDoesNotThrow(() -> consumer.consume(message));

--- a/backend/src/test/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducerTest.java
+++ b/backend/src/test/java/ru/vrata/backend/infrastructure/kafka/producer/KafkaProducerTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.core.KafkaTemplate;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
+import java.time.Instant;
+
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -13,7 +15,14 @@ class KafkaProducerTest {
     void produceShouldSendMessageToTopic() {
         KafkaTemplate<String, KafkaMessage> kafkaTemplate = mock(KafkaTemplate.class);
         KafkaProducer producer = new KafkaProducer(kafkaTemplate);
-        KafkaMessage message = new KafkaMessage("message-1", 1L, 10L, "username", "test");
+        KafkaMessage message = new KafkaMessage(
+                "message-1",
+                1L,
+                10L,
+                "username",
+                "test",
+                Instant.parse("2026-04-25T08:00:00Z")
+        );
         producer.produce(message);
         verify(kafkaTemplate).send(eq("chat-room-1"), eq("message-1"), eq(message));
     }

--- a/backend/src/test/java/ru/vrata/backend/infrastructure/websocket/StompMessageRealtimePublisherTest.java
+++ b/backend/src/test/java/ru/vrata/backend/infrastructure/websocket/StompMessageRealtimePublisherTest.java
@@ -5,6 +5,8 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
 
+import java.time.Instant;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -21,7 +23,8 @@ class StompMessageRealtimePublisherTest {
                 1L,
                 42L,
                 "rolan",
-                "hello"
+                "hello",
+                Instant.parse("2026-04-25T08:00:00Z")
         );
 
         publisher.publish(message);
@@ -38,5 +41,6 @@ class StompMessageRealtimePublisherTest {
         assertEquals(message.userId(), payload.userId());
         assertEquals(message.username(), payload.username());
         assertEquals(message.content(), payload.content());
+        assertEquals(message.timestamp(), payload.timestamp());
     }
 }


### PR DESCRIPTION
# Изменения
История сообщений больше не запрашивается по userId.
История хранится и читается на уровне комнаты (roomId) через отдельный room-based репозиторий.
В каждое сообщение добавлен timestamp (ISO datetime), чтобы фронт мог сортировать.
WebSocket payload тоже теперь содержит timestamp.

# Как выглядит endpoint истории теперь:
GET /api/v1/rooms/{roomId}/messages
