### PR TITLE
feat(consumer): integrate MongoDB storage instead of inline memory for consumer part

### DIFF
--- a/backend/src/main/java/ru/vrata/backend/domain/repository/inmemory/InMemoryRoomMessageRepository.java
+++ b/backend/src/main/java/ru/vrata/backend/domain/repository/inmemory/InMemoryRoomMessageRepository.java
@@ -3,6 +3,7 @@ package ru.vrata.backend.domain.repository.inmemory;
 import org.springframework.stereotype.Repository;
 import ru.vrata.backend.domain.repository.RoomMessageRepository;
 import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
+@ConditionalOnProperty(name = "app.repository", havingValue = "inmemory")
 public class InMemoryRoomMessageRepository implements RoomMessageRepository {
 
     private final Map<Long, List<KafkaMessage>> messagesByRoomId = new ConcurrentHashMap<>();

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/config/MongoUuidConfig.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/config/MongoUuidConfig.java
@@ -1,0 +1,15 @@
+package ru.vrata.backend.infrastructure.mongo.config;
+
+import org.bson.UuidRepresentation;
+import org.springframework.boot.mongodb.autoconfigure.MongoClientSettingsBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MongoUuidConfig {
+
+    @Bean
+    public MongoClientSettingsBuilderCustomizer mongoUuidCustomizer() {
+        return builder -> builder.uuidRepresentation(UuidRepresentation.STANDARD);
+    }
+}

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/document/MessageDocument.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/document/MessageDocument.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.Instant;
 import java.util.UUID;
 
 // TODO (consumer): use this for storing messages in MongoDB
@@ -20,4 +21,5 @@ public class MessageDocument {
     private Long userId;
     private String username;
     private String content;
+    private Instant timestamp;
 }

--- a/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/repository/MongoRoomMessageRepository.java
+++ b/backend/src/main/java/ru/vrata/backend/infrastructure/mongo/repository/MongoRoomMessageRepository.java
@@ -1,0 +1,65 @@
+package ru.vrata.backend.infrastructure.mongo.repository;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+import ru.vrata.backend.domain.model.Message;
+import ru.vrata.backend.domain.repository.RoomMessageRepository;
+import ru.vrata.backend.infrastructure.kafka.KafkaMessage;
+import ru.vrata.backend.infrastructure.mongo.document.MessageDocument;
+
+import java.util.List;
+
+@Repository
+@ConditionalOnProperty(name = "app.repository", havingValue = "mongo", matchIfMissing = true)
+public class MongoRoomMessageRepository implements RoomMessageRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public MongoRoomMessageRepository(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public void saveForRoom(Long roomId, KafkaMessage message) {
+        Message domainMessage = Message.from(message);
+        MessageDocument document = toDocument(domainMessage);
+        mongoTemplate.save(document);
+    }
+
+    @Override
+    public List<KafkaMessage> findByRoomId(Long roomId) {
+        Query query = Query.query(Criteria.where("roomId").is(roomId))
+                .with(Sort.by(Sort.Direction.ASC, "timestamp"));
+
+        return mongoTemplate.find(query, MessageDocument.class)
+                .stream()
+                .map(this::toKafkaMessage)
+                .toList();
+    }
+
+    private MessageDocument toDocument(Message message) {
+        return new MessageDocument(
+                message.id(),
+                message.roomId(),
+                message.userId(),
+                message.username(),
+                message.content(),
+                message.timestamp()
+        );
+    }
+
+    private KafkaMessage toKafkaMessage(MessageDocument document) {
+        return new KafkaMessage(
+                document.getId().toString(),
+                document.getRoomId(),
+                document.getUserId(),
+                document.getUsername(),
+                document.getContent(),
+                document.getTimestamp()
+        );
+    }
+}


### PR DESCRIPTION
Moved consumer-side room message storage from in-memory to MongoDB.

Changes:
- added MongoRoomMessageRepository
- updated MessageDocument with timestamp
- added Mongo UUID configuration for MessageDocument id
- kept InMemoryRoomMessageRepository only for app.repository=inmemory